### PR TITLE
fixing is_in_portfolio name search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dmypy.json
 .pyre/
 test.py
 .DS_Store
+trader.py

--- a/wikifolio.py
+++ b/wikifolio.py
@@ -851,8 +851,11 @@ class Wikifolio:
         """
         content = {}
         for underlying in self.get_content().underlyings:
-            _isin = self.search(underlying.name)[0].Isin
-            content[_isin] = underlying.amount
+            results = self.search(underlying.name)#[0].Isin
+            for result in results:
+                if isin in result.Isin:
+                    _isin = result.Isin
+                    content[_isin] = underlying.amount
         
         if isin in content:
             return True, content[isin]


### PR DESCRIPTION
when using is_in_portolio('DE0005550636') the original search is using the first result which is however 'DE0005550602' thus bool is False, which is wrong.
the PR now searches through all results comparing Isin to check whether it is really in the results and then correctly returns True.